### PR TITLE
Fixed an issue where sometimes there are models with a model_class() …

### DIFF
--- a/django_spaghetti/views.py
+++ b/django_spaghetti/views.py
@@ -16,6 +16,9 @@ def plate(request):
     nodes = []
     edges = []
     for model in models:
+        if (model.model_class() == None):
+            continue
+
         model.doc  = model.model_class().__doc__
         _id = "%s__%s"%(model.app_label,model.model)
         if _id in excludes:


### PR DESCRIPTION
…of None

The script would die and there wouldn't be any errors. Now the script will just pass over any object that doesn't have a model_class() to return. This may leave the DB diagram lacking a few objects but that's better than not showing any at all.