### PR TITLE
Fixed deprecated code

### DIFF
--- a/django_spaghetti/urls.py
+++ b/django_spaghetti/urls.py
@@ -1,6 +1,7 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import url
 from django.contrib import admin
+from django_spaghetti.views import plate
 
-urlpatterns = patterns('',
-    url(r'^$', 'django_spaghetti.views.plate', name='plate'),
-)
+urlpatterns = [
+    url(r'^$', plate, name='plate'),
+]

--- a/django_spaghetti/views.py
+++ b/django_spaghetti/views.py
@@ -35,6 +35,7 @@ def plate(request):
         for f in fields:
             f.ftype = str(f.__class__).split('.')[-1][:-2]
             if type(f) == related.ForeignKey:
+                # related_field deprecated in Django 1.9.
                 try:
                     _to = tuple(str(f.related_field).lower().split('.')[0:2])
                 except:
@@ -50,6 +51,7 @@ def plate(request):
                     }
                 )
             elif type(f) == related.OneToOneField:
+                # related_field deprecated in Django 1.9.
                 try:
                     _to = tuple(str(f.related_field).lower().split('.')[0:2])
                 except:
@@ -67,6 +69,7 @@ def plate(request):
                     }
                 )
         for f in parents:
+            # related_field deprecated in Django 1.9.
             try:
                 _to = tuple(str(f.related_field).lower().split('.')[0:2])
             except:

--- a/django_spaghetti/views.py
+++ b/django_spaghetti/views.py
@@ -35,7 +35,10 @@ def plate(request):
         for f in fields:
             f.ftype = str(f.__class__).split('.')[-1][:-2]
             if type(f) == related.ForeignKey:
-                _to = tuple(str(f.related_field).lower().split('.')[0:2])
+                try:
+                    _to = tuple(str(f.related_field).lower().split('.')[0:2])
+                except:
+                    _to = tuple(str(f.target_field).lower().split('.')[0:2])
                 if _to[0] != model.app_label:
                     edge_color = {'inherit':'both'}
                 edges.append(
@@ -47,7 +50,10 @@ def plate(request):
                     }
                 )
             elif type(f) == related.OneToOneField:
-                _to = tuple(str(f.related_field).lower().split('.')[0:2])
+                try:
+                    _to = tuple(str(f.related_field).lower().split('.')[0:2])
+                except:
+                    _to = tuple(str(f.target_field).lower().split('.')[0:2])
                 if _to[0] != model.app_label:
                     edge_color = {'inherit':'both'}
                 edges.append(
@@ -61,7 +67,10 @@ def plate(request):
                     }
                 )
         for f in parents:
-            _to = tuple(str(f.related_field).lower().split('.')[0:2])
+            try:
+                _to = tuple(str(f.related_field).lower().split('.')[0:2])
+            except:
+                _to = tuple(str(f.target_field).lower().split('.')[0:2])
             if _to[0] != model.app_label:
                 edge_color = {'inherit':'both'}
             edges.append(


### PR DESCRIPTION
Fixed changes in Django 1.9.
Name related_field was replaced by target_field.

django.conf.urls.patterns() is deprecated in Django 1.10.