### PR TITLE
option to show manytomanyfield details

### DIFF
--- a/django_spaghetti/tests/models.py
+++ b/django_spaghetti/tests/models.py
@@ -10,7 +10,11 @@ class PoliceOfficer(models.Model):
     first_name = models.CharField(max_length=200)
     surname = models.CharField(max_length=200)
     rank = models.CharField(max_length=200)
-    arrests = models.ManyToManyField("Arrest", related_name="arresting_officers")
+    arrests = models.ManyToManyField(
+        "Arrest",
+        related_name="arresting_officers",
+        help_text='All arrests made by the officer'
+    )
 
 
 class PoliceStation(models.Model):

--- a/django_spaghetti/tests/test_it.py
+++ b/django_spaghetti/tests/test_it.py
@@ -8,13 +8,22 @@ setup_test_environment()
 class LoadThePlate(TestCase):
     def test_plate(self):
         response = self.client.get("/")
+        resp_str = str(response.content)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('Officer' in str(response.content))
+        self.assertTrue('Officer' in resp_str)
+        self.assertTrue('All arrests made by the officer' not in resp_str)
 
     def test_plate_with_settings(self):
         response = self.client.get("/test/plate_settings")
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Officer' not in str(response.content))
+
+    def test_plate_show_m2m_field_detail(self):
+        response = self.client.get("/test/plate_show_m2m_field_detail")
+        resp_str = str(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Officer' in resp_str)
+        self.assertTrue('All arrests made by the officer' in resp_str)
 
     def test_plate_with_override_settings(self):
         response = self.client.get("/test/plate_override")

--- a/django_spaghetti/tests/urls.py
+++ b/django_spaghetti/tests/urls.py
@@ -9,6 +9,11 @@ urlpatterns = [
             'exclude': {},
         }
     ), name='test_plate_settings'),
+    url(r'^test/plate_show_m2m_field_detail$', Plate.as_view(
+        override_settings={
+            'show_m2m_field_detail': True
+        }
+    ), name='test_plate_show_m2m_field_detail'),
     url(r'^test/plate_override$', Plate.as_view(
         override_settings={
             'exclude': {

--- a/django_spaghetti/views.py
+++ b/django_spaghetti/views.py
@@ -129,6 +129,9 @@ class Plate(View):
                 }
                 edges.append(edge)
 
+            all_node_fields = fields
+            if graph_settings.get('show_m2m_field_detail', False):
+                all_node_fields = fields + many
             nodes.append(
                 {
                     'id': _id,
@@ -136,7 +139,7 @@ class Plate(View):
                     'shape': 'box',
                     'group': model.app_label,
                     'title': get_template(self.meatball_template_name).render(
-                        {'model': model, 'fields': fields}
+                        {'model': model, 'fields': all_node_fields}
                         )
                 }
             )

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -46,14 +46,15 @@ variable from your projects ``settings.py`` file that make it `extra spicy`::
     'show_fields':False,
     'exclude':{'auth':['user']},
     'show_proxy':True,
+    'show_m2m_field_detail':False
   }
 
 In the above dictionary, the following settings are used:
 
 * ``apps`` is a list of apps you want to show in the graph. If its `not` in here it `won't be seen`.
 * ``show_fields`` is a boolean that states if the field names should be shown in the graph or just in the however over. For small graphs, you can set this to `True` to show fields as well, but as you get more models it gets messier.
-* ``exclude`` is a dictionary where each key is an ``app_label`` and the items for that key are model names to hide in the graph. 
+* ``exclude`` is a dictionary where each key is an ``app_label`` and the items for that key are model names to hide in the graph.
 * ``show_proxy`` is boolean, if truthy proxy models will be shown and linked to their main model, otherwise they will be hidden. By default this is false.
+* ``show_m2m_field_detail`` is boolean, if truthy ``ManyToManyField``s will be shown with their documentation in the detailed content for a model. By default this is false.
 
 If its not working as expected make sure your app labels and model names are all **lower case**.
-


### PR DESCRIPTION
@LegoStormtroopr Looks like `ManyToManyField`s don't show in the node detail by default. This PR adds an option to show that information there.