### PR TITLE
ftype -> get_internal_type(), deepcopy django settings

### DIFF
--- a/django_spaghetti/templates/django_spaghetti/meatball.html
+++ b/django_spaghetti/templates/django_spaghetti/meatball.html
@@ -15,7 +15,7 @@
         {% for field in fields %}
         <li>
             {% if field.unique %}<u>{{field.name}}</u>{%else%}{{field.name}}{%endif%}
-            <small>{{field.ftype}}</small><br>
+            <small>{{field.get_internal_type}}</small><br>
             <small>{{field.help_text}}</small>
         </li>
         {% endfor %}

--- a/django_spaghetti/tests/test_it.py
+++ b/django_spaghetti/tests/test_it.py
@@ -30,3 +30,26 @@ class LoadThePlate(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('policeofficer' in str(response.content).lower())
         self.assertTrue('policestation' not in str(response.content).lower())
+
+    def test_no_override_after_override(self):
+        response1 = self.client.get("/test/plate_override")
+        response2 = self.client.get("/")
+        resp_str = str(response2.content)
+        self.assertEqual(response1.status_code, 200)
+        self.assertEqual(response2.status_code, 200)
+        self.assertTrue('policeofficer' in str(response1.content).lower())
+        self.assertTrue('policestation' not in str(response1.content).lower())
+        self.assertTrue('Officer' in resp_str)
+        self.assertTrue('All arrests made by the officer' not in resp_str)
+
+    def test_meatball(self):
+        response = self.client.get("/test/plate_show_m2m_field_detail")
+        resp_str = str(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('IntegerField' in resp_str)
+        self.assertTrue('CharField' in resp_str)
+        self.assertTrue('ManyToManyField' in resp_str)
+        self.assertTrue('ForeignKey' in resp_str)
+        self.assertTrue('OneToOneField' in resp_str)
+        self.assertTrue('DateField' in resp_str)
+        self.assertTrue('URLField' not in resp_str)

--- a/django_spaghetti/views.py
+++ b/django_spaghetti/views.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import render
 
@@ -45,7 +47,7 @@ class Plate(View):
         """
         request = self.request
         if self.settings is None:
-            graph_settings = getattr(settings, 'SPAGHETTI_SAUCE', {})
+            graph_settings = deepcopy(getattr(settings, 'SPAGHETTI_SAUCE', {}))
             graph_settings.update(self.override_settings)
         else:
             graph_settings = self.settings


### PR DESCRIPTION
Hi Samuel,
I ran into the same issue as #19 and when I looked into it, I saw that the problem was when we try to output `field.ftype` in the template, but `ftype` is a non-existant attribute. I changed it to use `get_internal_type()` and added a `test_meatball` to check that all the existing field types get output to the template (and a non-existent field type is *not* output). As a side effect of adding the new test, the tests ran in a different order and I found another bug where the global django settings were getting overridden permanently by settings in `override_settings`. I used `copy.deepcopy` to prevent this and wrote a new test which fails before the change and passes afterward.